### PR TITLE
Create Project button now resets after project creation

### DIFF
--- a/src/autotrain/app.py
+++ b/src/autotrain/app.py
@@ -521,7 +521,6 @@ def disable_create_project_button():
 
 
 def enable_create_project_button():
-    print("got to enable_create_project_button")
     return gr.Button.update(interactive=True)
 
 

--- a/src/autotrain/app.py
+++ b/src/autotrain/app.py
@@ -520,6 +520,11 @@ def disable_create_project_button():
     return gr.Button.update(interactive=False)
 
 
+def enable_create_project_button():
+    print("got to enable_create_project_button")
+    return gr.Button.update(interactive=True)
+
+
 def main():
     with gr.Blocks(theme="freddyaboulton/dracula_revamped") as demo:
         gr.Markdown("## 🤗 AutoTrain Advanced")
@@ -955,8 +960,7 @@ def main():
                 autotrain_backend,
             ],
             outputs=final_output,
-        )
-
+        ).then(enable_create_project_button, None, create_project_button)
         demo.load(
             _update_project_name,
             outputs=[project_name, create_project_button],


### PR DESCRIPTION
closes #151

I've tested this solution on a local build on the following tasks:
1. Create multiple projects using Huggingface Internal.
2. Create a project after a "please add at least 1 job" error.

I've also tested this on a Huggingface Space docker image on the following tasks:
1. Create a Huggingface Spaces project after a "please add at least 1 job"
2. Create a Huggingface Spaces project and then follow it with a Huggingface Internal project.