### PR TITLE
fix: :bug: Setting `exist_ok` as `True` incase `push_to_hub` is `True`

### DIFF
--- a/src/autotrain/trainers/clm.py
+++ b/src/autotrain/trainers/clm.py
@@ -299,7 +299,7 @@ def train(config):
     if config.push_to_hub:
         logger.info("Pushing model to hub...")
         api = HfApi()
-        api.create_repo(repo_id=config.repo_id, repo_type="model")
+        api.create_repo(repo_id=config.repo_id, repo_type="model", exist_ok=True)
         api.upload_folder(folder_path=config.project_name, repo_id=config.repo_id, repo_type="model")
 
 


### PR DESCRIPTION
This fix is for the issue described here: https://github.com/huggingface/autotrain-advanced/issues/163

Due to exist_ok being set to false, we can't retrain the same model and push it to the same repo.