### PR TITLE
fix help text for peft

### DIFF
--- a/src/autotrain/cli/run_llm.py
+++ b/src/autotrain/cli/run_llm.py
@@ -205,7 +205,7 @@ class RunAutoTrainLLMCommand(BaseAutoTrainCommand):
         )
         run_llm_parser.add_argument(
             "--use_peft",
-            help="Use PEFT to use",
+            help="Use PEFT",
             required=False,
             action="store_true",
         )


### PR DESCRIPTION
typo in command line help text