### PR TITLE
Enable using both --train-text-encoder and --use-prior-preservation

### DIFF
--- a/src/autotrain/trainers/dreambooth/trainer.py
+++ b/src/autotrain/trainers/dreambooth/trainer.py
@@ -302,7 +302,7 @@ class Trainer:
                     prompt=None,
                     text_input_ids_list=[self.tokens_one, self.tokens_two],
                 )
-                unet_added_conditions.update({"text_embeds": pooled_prompt_embeds.repeat(bsz, 1)})
+                unet_added_conditions.update({"text_embeds": pooled_prompt_embeds.repeat(elems_to_repeat, 1)})
                 prompt_embeds = prompt_embeds.repeat(elems_to_repeat, 1, 1)
                 model_pred = self.unet(
                     noisy_model_input, timesteps, prompt_embeds, added_cond_kwargs=unet_added_conditions


### PR DESCRIPTION
There is a bug caused by a typo that is described in this Github issue, which causes a matrix multiply error when using both train text encoder and prior preservation. 

https://github.com/huggingface/autotrain-advanced/issues/228

I've forked and corrected the typo and the training process is working again with both options enabled.