### PR TITLE
Space Runner: fix cli args

### DIFF
--- a/src/autotrain/cli/run_spacerunner.py
+++ b/src/autotrain/cli/run_spacerunner.py
@@ -55,13 +55,13 @@ class RunAutoTrainSpaceRunnerCommand(BaseAutoTrainCommand):
                 "help": "Hugging Face backend to use",
                 "required": True,
                 "type": str,
+                "choices": BACKEND_CHOICES,
             },
             {
                 "arg": "--env",
                 "help": "Environment variables, e.g. --env FOO=bar;FOO2=bar2;FOO3=bar3",
                 "required": False,
                 "type": str,
-                "choices": BACKEND_CHOICES,
             },
         ]
         run_spacerunner_parser = parser.add_parser("spacerunner", description="✨ Run AutoTrain SpaceRunner")


### PR DESCRIPTION
Hey,

this PR fixes the cli args for `--backend` and `--env` parameters. Currently, the help page shows:

```bash
 --backend BACKEND     Hugging Face backend to use
  --env {spaces-a10gl,spaces-a10gs,spaces-a100,spaces-t4m,spaces-t4s,spaces-cpu,spaces-cpuf}
                        Environment variables, e.g. --env FOO=bar;FOO2=bar2;FOO3=bar3
```

As you can see, the backend options are unfortunately used for the `env` parameter (and not for `backend`).

This PR fixes it to:

```bash
  --backend {spaces-a10gl,spaces-a10gs,spaces-a100,spaces-t4m,spaces-t4s,spaces-cpu,spaces-cpuf}
                        Hugging Face backend to use
  --env ENV             Environment variables, e.g. --env FOO=bar;FOO2=bar2;FOO3=bar3
```