### PR TITLE
define `pad_token_id` in GenerationConfig to avoid log during inference

### DIFF
--- a/src/autotrain/infer/text_generation.py
+++ b/src/autotrain/infer/text_generation.py
@@ -42,6 +42,8 @@ class TextGenerationInference:
             eos_token_id=self.tokenizer.eos_token_id,
             do_sample=self.do_sample,
             max_new_tokens=self.max_new_tokens,
+            pad_token_id=self.tokenizer.eos_token_id
+
         )
 
     def chat(self, prompt):


### PR DESCRIPTION
Explicitly define `pad_token_id` in `GenerationConfig` as `tokenizer.eos_token_id` to avoid printing of `Setting \`pad_token_id\` to \`eos_token_id\`:2 for open-end generation.` when running inference using TextGenerationInference from autotrain-advanced/src/autotrain/infer/text_generation.py