### PR TITLE
fix csv data loading bug in llm ft

### DIFF
--- a/src/autotrain/cli/utils.py
+++ b/src/autotrain/cli/utils.py
@@ -208,7 +208,9 @@ def llm_munge_data(params, local):
             local=local,
         )
         params.data_path = dset.prepare()
-        params.valid_split = None
+        params.train_split = "train"
+        if params.valid_split:
+            params.valid_split = "validation"
         params.text_column = "autotrain_text"
         params.rejected_text_column = "autotrain_rejected_text"
         params.prompt_text_column = "autotrain_prompt"


### PR DESCRIPTION
There is a bug while using csv files for fine-tuning llms. In *autotrain-advanced/src/autotrain/cli/utils.py* line 211 params.valid_split is set to None which is why validation set will never be loaded. This is because AutoTrainDataset class's prepare method creates hf arrow datasets using the csv files and saves them at *{PROJECT_NAME}/autotrain-data/train* and *{PROJECT_NAME}/autotrain-data/validation* repectively. The changes that I have made in the *autotrain-advanced/src/autotrain/cli/utils.py* fixes the bug.