### PR TITLE
Apply deprecated `evaluation_strategy`

### DIFF
--- a/src/autotrain/app.py
+++ b/src/autotrain/app.py
@@ -238,7 +238,7 @@ async def fetch_params(task: str, param_type: str):
                         "use_flash_attention_2",
                         "disable_gradient_checkpointing",
                         "logging_steps",
-                        "evaluation_strategy",
+                        "eval_strategy",
                         "save_total_limit",
                         "save_strategy",
                         "auto_find_batch_size",
@@ -264,7 +264,7 @@ async def fetch_params(task: str, param_type: str):
                 "auto_find_batch_size",
                 "save_total_limit",
                 "save_strategy",
-                "evaluation_strategy",
+                "eval_strategy",
             ]
             task_params = {k: v for k, v in task_params.items() if k not in more_hidden_params}
         if task == "image-classification" and param_type == "basic":
@@ -277,7 +277,7 @@ async def fetch_params(task: str, param_type: str):
                 "auto_find_batch_size",
                 "save_total_limit",
                 "save_strategy",
-                "evaluation_strategy",
+                "eval_strategy",
             ]
             task_params = {k: v for k, v in task_params.items() if k not in more_hidden_params}
         if task == "seq2seq" and param_type == "basic":
@@ -290,7 +290,7 @@ async def fetch_params(task: str, param_type: str):
                 "auto_find_batch_size",
                 "save_total_limit",
                 "save_strategy",
-                "evaluation_strategy",
+                "eval_strategy",
                 "quantization",
                 "lora_r",
                 "lora_alpha",
@@ -308,7 +308,7 @@ async def fetch_params(task: str, param_type: str):
                 "auto_find_batch_size",
                 "save_total_limit",
                 "save_strategy",
-                "evaluation_strategy",
+                "eval_strategy",
             ]
             task_params = {k: v for k, v in task_params.items() if k not in more_hidden_params}
         if task == "dreambooth":

--- a/src/autotrain/cli/run_llm.py
+++ b/src/autotrain/cli/run_llm.py
@@ -139,7 +139,7 @@ class RunAutoTrainLLMCommand(BaseAutoTrainCommand):
                 "alias": ["--logging-steps"],
             },
             {
-                "arg": "--evaluation_strategy",
+                "arg": "--eval_strategy",
                 "help": "Evaluation strategy to use",
                 "required": False,
                 "type": str,

--- a/src/autotrain/trainers/clm/__main__.py
+++ b/src/autotrain/trainers/clm/__main__.py
@@ -225,7 +225,7 @@ def train(config):
         per_device_eval_batch_size=config.batch_size,
         learning_rate=config.lr,
         num_train_epochs=config.epochs,
-        evaluation_strategy=config.evaluation_strategy if config.valid_split is not None else "no",
+        eval_strategy=config.eval_strategy if config.valid_split is not None else "no",
         logging_steps=logging_steps,
         save_total_limit=config.save_total_limit,
         save_strategy=config.save_strategy,

--- a/src/autotrain/trainers/clm/params.py
+++ b/src/autotrain/trainers/clm/params.py
@@ -24,7 +24,7 @@ class LLMTrainingParams(AutoTrainParams):
     log: str = Field("none", title="Logging using experiment tracking")
     disable_gradient_checkpointing: bool = Field(False, title="Gradient checkpointing")
     logging_steps: int = Field(-1, title="Logging steps")
-    evaluation_strategy: str = Field("epoch", title="Evaluation strategy")
+    eval_strategy: str = Field("epoch", title="Evaluation strategy")
     save_total_limit: int = Field(1, title="Save total limit")
     save_strategy: str = Field("no", title="Save strategy")
     auto_find_batch_size: bool = Field(False, title="Auto find batch size")

--- a/src/autotrain/trainers/image_classification/__main__.py
+++ b/src/autotrain/trainers/image_classification/__main__.py
@@ -125,7 +125,7 @@ def train(config):
         per_device_eval_batch_size=2 * config.batch_size,
         learning_rate=config.lr,
         num_train_epochs=config.epochs,
-        evaluation_strategy=config.evaluation_strategy if config.valid_split is not None else "no",
+        eval_strategy=config.eval_strategy if config.valid_split is not None else "no",
         logging_steps=logging_steps,
         save_total_limit=config.save_total_limit,
         save_strategy=config.save_strategy,

--- a/src/autotrain/trainers/image_classification/params.py
+++ b/src/autotrain/trainers/image_classification/params.py
@@ -30,7 +30,7 @@ class ImageClassificationParams(AutoTrainParams):
     token: Optional[str] = Field(None, title="Hub Token")
     push_to_hub: bool = Field(False, title="Push to hub")
     repo_id: Optional[str] = Field(None, title="Repo id")
-    evaluation_strategy: str = Field("epoch", title="Evaluation strategy")
+    eval_strategy: str = Field("epoch", title="Evaluation strategy")
     image_column: str = Field("image", title="Image column")
     target_column: str = Field("target", title="Target column")
     log: str = Field("none", title="Logging using experiment tracking")

--- a/src/autotrain/trainers/seq2seq/__main__.py
+++ b/src/autotrain/trainers/seq2seq/__main__.py
@@ -101,7 +101,7 @@ def train(config):
         per_device_eval_batch_size=2 * config.batch_size,
         learning_rate=config.lr,
         num_train_epochs=config.epochs,
-        evaluation_strategy=config.evaluation_strategy if config.valid_split is not None else "no",
+        eval_strategy=config.eval_strategy if config.valid_split is not None else "no",
         logging_steps=logging_steps,
         save_total_limit=config.save_total_limit,
         save_strategy=config.save_strategy,

--- a/src/autotrain/trainers/seq2seq/params.py
+++ b/src/autotrain/trainers/seq2seq/params.py
@@ -30,7 +30,7 @@ class Seq2SeqParams(AutoTrainParams):
     weight_decay: float = Field(0.0, title="Weight decay")
     max_grad_norm: float = Field(1.0, title="Max gradient norm")
     logging_steps: int = Field(-1, title="Logging steps")
-    evaluation_strategy: str = Field("epoch", title="Evaluation strategy")
+    eval_strategy: str = Field("epoch", title="Evaluation strategy")
     auto_find_batch_size: bool = Field(False, title="Auto find batch size")
     mixed_precision: Optional[str] = Field(None, title="fp16, bf16, or None")
     save_total_limit: int = Field(1, title="Save total limit")

--- a/src/autotrain/trainers/text_classification/__main__.py
+++ b/src/autotrain/trainers/text_classification/__main__.py
@@ -132,7 +132,7 @@ def train(config):
         per_device_eval_batch_size=2 * config.batch_size,
         learning_rate=config.lr,
         num_train_epochs=config.epochs,
-        evaluation_strategy=config.evaluation_strategy if config.valid_split is not None else "no",
+        eval_strategy=config.eval_strategy if config.valid_split is not None else "no",
         logging_steps=logging_steps,
         save_total_limit=config.save_total_limit,
         save_strategy=config.save_strategy,

--- a/src/autotrain/trainers/text_classification/params.py
+++ b/src/autotrain/trainers/text_classification/params.py
@@ -32,6 +32,6 @@ class TextClassificationParams(AutoTrainParams):
     token: Optional[str] = Field(None, title="Hub Token")
     push_to_hub: bool = Field(False, title="Push to hub")
     repo_id: Optional[str] = Field(None, title="Repo id")
-    evaluation_strategy: str = Field("epoch", title="Evaluation strategy")
+    eval_strategy: str = Field("epoch", title="Evaluation strategy")
     username: Optional[str] = Field(None, title="Hugging Face Username")
     log: str = Field("none", title="Logging using experiment tracking")

--- a/src/autotrain/trainers/token_classification/__main__.py
+++ b/src/autotrain/trainers/token_classification/__main__.py
@@ -128,7 +128,7 @@ def train(config):
         per_device_eval_batch_size=2 * config.batch_size,
         learning_rate=config.lr,
         num_train_epochs=config.epochs,
-        evaluation_strategy=config.evaluation_strategy if config.valid_split is not None else "no",
+        eval_strategy=config.eval_strategy if config.valid_split is not None else "no",
         logging_steps=logging_steps,
         save_total_limit=config.save_total_limit,
         save_strategy=config.save_strategy,

--- a/src/autotrain/trainers/token_classification/params.py
+++ b/src/autotrain/trainers/token_classification/params.py
@@ -32,6 +32,6 @@ class TokenClassificationParams(AutoTrainParams):
     token: Optional[str] = Field(None, title="Hub Token")
     push_to_hub: bool = Field(False, title="Push to hub")
     repo_id: Optional[str] = Field(None, title="Repo id")
-    evaluation_strategy: str = Field("epoch", title="Evaluation strategy")
+    eval_strategy: str = Field("epoch", title="Evaluation strategy")
     username: Optional[str] = Field(None, title="Hugging Face Username")
     log: str = Field("none", title="Logging using experiment tracking")


### PR DESCRIPTION
This PR applies the deprecated `evaluation_strategy` from https://github.com/huggingface/transformers/pull/30190.

TL;DR: `evaluation_strategy` -> `eval_strategy`

(Should go live in v4.41.0, but opening now so it's here when ready!)