### PR TITLE
Fixed typo on trending_models.sort

### DIFF
--- a/src/autotrain/app/models.py
+++ b/src/autotrain/app/models.py
@@ -38,7 +38,7 @@ def _fetch_text_classification_models():
         list_models(
             task="fill-mask",
             library="transformers",
-            sort="likes7d",
+            sort="likes",
             direction=-1,
             limit=30,
             full=False,


### PR DESCRIPTION
Fixing the "likes7d" typo that's causing the autotrain colab UI to fail when calling colab_app()