### PR TITLE
Fix 'no such option: -U' error

### DIFF
--- a/src/autotrain/cli/run_setup.py
+++ b/src/autotrain/cli/run_setup.py
@@ -37,7 +37,7 @@ class RunSetupCommand(BaseAutoTrainCommand):
         if self.colab:
             cmd = "pip install -U xformers==0.0.24"
         else:
-            cmd = "pip uninstall -U xformers"
+            cmd = "pip uninstall -y xformers"
         cmd = cmd.split()
         pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         logger.info("Installing latest xformers")


### PR DESCRIPTION
On space startup I'm seeing:
```
===== Application Startup at 2024-07-03 00:09:46 =====


Usage:   
  pip uninstall [options] <package> ...
  pip uninstall [options] -r <requirements file> ...

no such option: -U
=== Application stopped (exit code: 2) at 2024-07-03 00:09:52.959388774 UTC ===
```

This seems to be caused by `pip uninstall -U xformers` on line: https://github.com/huggingface/autotrain-advanced/blame/60aa443952017024e6c7b0eb2b5c2996782866f8/src/autotrain/cli/run_setup.py#L40

`-U` does not seem to have ever been a valid option for `uninstall`