### PR TITLE
Update vision.py

### DIFF
--- a/src/autotrain/preprocessor/vision.py
+++ b/src/autotrain/preprocessor/vision.py
@@ -62,7 +62,7 @@ class ImageClassificationPreprocessor:
             if train_subfolders != valid_subfolders:
                 raise ValueError(f"{self.valid_data} should have the same subfolders as {self.train_data}.")
 
-            if len(subfolders) < 2:
+            if len(subfolders) <= 2:
                 raise ValueError(f"{self.valid_data} should contain at least 2 subfolders.")
 
             # Check if each subfolder contains at least 5 image files in jpeg, png or jpg format only


### PR DESCRIPTION
If you only use 2 subfolders for image training this fails. Problem: len() begins at 1 (not zero).

Example:
subfolders = ['sub1','sub2']
print(len(subfolders))
>>2

Original (less than): <
Change Suggested (less than or equal to): <=

(You could also change it to < 3.)

Error Message from Hugging Face Auto Train Log:

ValueError: /app/.cache/autotrain/96b51566-7f4f-410e-978e-9e23255271cc should contain at least 2 subfolders.

raise ValueError(f"{self.train_data} should contain at least 2 subfolders.") File "/app/env/lib/python3.10/site-packages/autotrain/preprocessor/vision.py", line 35, in __post_init__

Thank you.