### PR TITLE
Fixed #690

### DIFF
--- a/src/autotrain/cli/utils.py
+++ b/src/autotrain/cli/utils.py
@@ -273,7 +273,7 @@ def llm_munge_data(params, local):
             ext=ext_to_use,
         )
         params.data_path = dset.prepare()
-        params.valid_split = None
+        params.valid_split = "validation"
         params.text_column = "autotrain_text"
         params.rejected_text_column = "autotrain_rejected_text"
         params.prompt_text_column = "autotrain_prompt"

--- a/src/autotrain/trainers/clm/utils.py
+++ b/src/autotrain/trainers/clm/utils.py
@@ -445,7 +445,7 @@ def get_tokenizer(config):
 
 
 def process_data_with_chat_template(config, tokenizer, train_data, valid_data):
-    valid_data = None
+    # valid_data = None
     if config.chat_template in ("chatml", "zephyr", "tokenizer"):
         logger.info("Applying chat template")
         logger.info("For ORPO/DPO, `prompt` will be extracted from chosen messages")


### PR DESCRIPTION
The valid_split was being set to none before applying the chat template in SFT, which was leading to errors.

The valid_split parameter was being set to None in the CLI before this which was disabling the use of a val set during fine tuning of an LLM.