### PR TITLE
Add hf_private configuration option for model repository privacy, in dreambooth training

### DIFF
--- a/src/autotrain/parser.py
+++ b/src/autotrain/parser.py
@@ -210,6 +210,7 @@ class AutoTrainConfigParser:
             params["username"] = self.config["hub"]["username"]
             params["token"] = self.config["hub"]["token"]
             params["push_to_hub"] = self.config["hub"]["push_to_hub"]
+            params["hf_private"] = self.config["hub"]["hf_private"]
         else:
             params["username"] = None
             params["token"] = None

--- a/src/autotrain/trainers/dreambooth/__main__.py
+++ b/src/autotrain/trainers/dreambooth/__main__.py
@@ -105,6 +105,7 @@ def train(config):
             max_grad_norm = config.max_grad_norm
             push_to_hub = config.push_to_hub
             hub_token = config.token
+            hf_private=config.hf_private
             hub_model_id = f"{config.username}/{config.project_name}"
             logging_dir = os.path.join(config.project_name, "logs")
             allow_tf32 = config.allow_tf32
@@ -165,6 +166,7 @@ def train(config):
             adam_epsilon = config.adam_epsilon
             max_grad_norm = config.max_grad_norm
             push_to_hub = config.push_to_hub
+            hf_private=config.hf_private
             hub_token = config.token
             hub_model_id = f"{config.username}/{config.project_name}"
             logging_dir = os.path.join(config.project_name, "logs")
@@ -213,7 +215,7 @@ def train(config):
         repo_id = create_repo(
             repo_id=f"{config.username}/{config.project_name}",
             exist_ok=True,
-            private=True,
+            private=config.hf_private,
             token=config.token,
         ).repo_id
         if config.xl:

--- a/src/autotrain/trainers/dreambooth/params.py
+++ b/src/autotrain/trainers/dreambooth/params.py
@@ -129,6 +129,7 @@ class DreamBoothTrainingParams(AutoTrainParams):
     token: Optional[str] = Field(None, title="Token for accessing the model hub")
     push_to_hub: bool = Field(False, title="Enable pushing the model to the hub")
     username: Optional[str] = Field(None, title="Username for the model hub")
+    hf_private : bool = Field(True, title="keep the model repository private")
 
     # disabled:
     validation_prompt: Optional[str] = Field(None, title="Prompt for validation images")

--- a/src/autotrain/trainers/dreambooth/trainer.py
+++ b/src/autotrain/trainers/dreambooth/trainer.py
@@ -464,7 +464,7 @@ class Trainer:
         repo_id = create_repo(
             repo_id=f"{self.config.username}/{self.config.project_name}",
             exist_ok=True,
-            private=True,
+            private=self.config.hf_private,
             token=self.config.token,
         ).repo_id
 

--- a/src/autotrain/trainers/dreambooth/utils.py
+++ b/src/autotrain/trainers/dreambooth/utils.py
@@ -1,11 +1,9 @@
 import os
-
 from huggingface_hub import list_models
-
 from autotrain import logger
 
-
 VALID_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"]
+
 try:
     XL_MODELS = [
         m.id
@@ -28,18 +26,16 @@ except Exception:
         "stabilityai/sdxl-turbo",
     ]
 
-
 def save_model_card_xl(
     repo_id: str,
-    base_model=str,
-    train_text_encoder=False,
-    instance_prompt=str,
-    repo_folder=None,
-    vae_path=None,
+    base_model: str,
+    train_text_encoder: bool,
+    instance_prompt: str,
+    repo_folder: str = None,
+    vae_path: str = None,
 ):
     img_str = ""
-    yaml = f"""
----
+    yaml = f"""---
 tags:
 - autotrain
 - stable-diffusion-xl
@@ -52,56 +48,56 @@ tags:
 base_model: {base_model}
 instance_prompt: {instance_prompt}
 license: openrail++
----
-    """
+---"""
 
-    model_card = f"""
-# AutoTrain SDXL LoRA DreamBooth - {repo_id}
-
+    model_card = f"""# ModelsLab LoRA DreamBooth Training - {repo_id}
 <Gallery />
 
 ## Model description
-
 These are {repo_id} LoRA adaption weights for {base_model}.
-
-The weights were trained  using [DreamBooth](https://dreambooth.github.io/).
-
+The weights were trained using [Modelslab](https://modelslab.com).
 LoRA for the text encoder was enabled: {train_text_encoder}.
-
 Special VAE used for training: {vae_path}.
 
-## Trigger words
+## Use it with the [🧨 diffusers library](https://github.com/huggingface/diffusers)
+```py
+!pip install -q transformers accelerate peft diffusers
+from diffusers import DiffusionPipeline
+import torch
 
+pipe_id = "stabilityai/stable-diffusion-xl-base-1.0"
+pipe = DiffusionPipeline.from_pretrained(pipe_id, torch_dtype=torch.float16).to("cuda")
+pipe.load_lora_weights("{repo_id}", weight_name="pytorch_lora_weights.safetensors", adapter_name="abc")
+prompt = "abc of a hacker with a hoodie"
+lora_scale = 0.9
+image = pipe(
+    prompt,
+    num_inference_steps=30,
+    cross_attention_kwargs={{"scale": lora_scale}},
+    generator=torch.manual_seed(0)
+).images[0]
+image
+```
+
+## Trigger words
 You should use {instance_prompt} to trigger the image generation.
 
 ## Download model
-
 Weights for this model are available in Safetensors format.
+[Download]({repo_id}/tree/main) them in the Files & versions tab."""
 
-[Download]({repo_id}/tree/main) them in the Files & versions tab.
-
-"""
     with open(os.path.join(repo_folder, "README.md"), "w") as f:
-        f.write(yaml + model_card)
-
+        f.write(yaml + "\n" + model_card)
 
 def save_model_card(
     repo_id: str,
-    base_model=str,
-    train_text_encoder=False,
-    instance_prompt=str,
-    repo_folder=None,
+    base_model: str,
+    train_text_encoder: bool,
+    instance_prompt: str,
+    repo_folder: str = None,
 ):
     img_str = ""
-    model_description = f"""
-# AutoTrain LoRA DreamBooth - {repo_id}
-
-These are LoRA adaption weights for {base_model}. The weights were trained on {instance_prompt} using [DreamBooth](https://dreambooth.github.io/).
-LoRA for the text encoder was enabled: {train_text_encoder}.
-"""
-
-    yaml = f"""
----
+    yaml = f"""---
 tags:
 - autotrain
 - stable-diffusion
@@ -114,7 +110,31 @@ tags:
 base_model: {base_model}
 instance_prompt: {instance_prompt}
 license: openrail++
----
-    """
+---"""
+
+    model_description = f"""# ModelsLab LoRA DreamBooth Training - {repo_id}
+These are LoRA adaption weights for {base_model}. The weights were trained on {instance_prompt} using [ModelsLab](https://modelslab.com).
+LoRA for the text encoder was enabled: {train_text_encoder}.
+
+## Use it with the [🧨 diffusers library](https://github.com/huggingface/diffusers)
+```py
+!pip install -q transformers accelerate peft diffusers
+from diffusers import DiffusionPipeline
+import torch
+
+pipe_id = "Lykon/DreamShaper"
+pipe = DiffusionPipeline.from_pretrained(pipe_id, torch_dtype=torch.float16).to("cuda")
+pipe.load_lora_weights("{repo_id}", weight_name="pytorch_lora_weights.safetensors", adapter_name="abc")
+prompt = "abc of a hacker with a hoodie"
+lora_scale = 0.9
+image = pipe(
+    prompt,
+    num_inference_steps=30,
+    cross_attention_kwargs={{"scale": 0.9}},
+    generator=torch.manual_seed(0)
+).images[0]
+image
+```"""
+
     with open(os.path.join(repo_folder, "README.md"), "w") as f:
-        f.write(yaml + model_description)
+        f.write(yaml + "\n" + model_description)


### PR DESCRIPTION
private/public repo support in dreambooth

parameter name: hf_private

example config:
```

        task: dreambooth
        base_model: Lykon/DreamShaper
        project_name: my-stablediffusion-lora-611
        log: wandb
        backend: local
    
        data:
          path: data
          prompt: best quality, aqua eyes, baseball cap, closed mouth, green background, hat, looking at viewer, shirt, short hair, simple background, solo, upper body, yellow shirt
    
        params:
          resolution: 512
          lr: 0.0005
          num_steps: 3
          batch_size: 4
          gradient_accumulation: 4
          mixed_precision: fp16
          train_text_encoder: False
          xformers: False
          use_8bit_adam: False
          xl: False
          rank: 16
    
        hub:
          username: mlgawd
          token: hf_qgzyXhXDCgNSaildgiuFb
          push_to_hub: True
          hf_private: True
```
open to feedbacks and reviews.
        