### PR TITLE
Create new log file when unexitsts

### DIFF
--- a/src/autotrain/app/ui_routes.py
+++ b/src/autotrain/app/ui_routes.py
@@ -756,6 +756,9 @@ async def fetch_logs(authenticated: bool = Depends(user_authentication)):
     if not AUTOTRAIN_LOCAL:
         return {"logs": "Logs are only available in local mode."}
     log_file = "autotrain.log"
+    if not os.path.exists(log_file):
+        with open(log_file, "w", encoding="utf-8") as f:
+            pass
     with open(log_file, "r", encoding="utf-8") as f:
         logs = f.read()
     if len(str(logs).strip()) == 0:


### PR DESCRIPTION
Hello,

I think this is a small fix for an error occurs when I run a training task in the web UI using `src/autotrain/app/app.py`. The issue is that the fetch_logs function attempts to read the autotrain.log file even the file doesn't exist.