### PR TITLE
removed "auto" as possible choice for max_features in ExtraTreesClass…

### DIFF
--- a/src/autotrain/trainers/tabular/utils.py
+++ b/src/autotrain/trainers/tabular/utils.py
@@ -287,7 +287,7 @@ def get_params(trial, model, task):
         params = {
             "n_estimators": trial.suggest_int("n_estimators", 10, 10000),
             "max_depth": trial.suggest_int("max_depth", 2, 15),
-            "max_features": trial.suggest_categorical("max_features", ["auto", "sqrt", "log2", None]),
+            "max_features": trial.suggest_categorical("max_features", ["sqrt", "log2", None]),
             "min_samples_split": trial.suggest_int("min_samples_split", 2, 20),
             "min_samples_leaf": trial.suggest_int("min_samples_leaf", 1, 20),
             "bootstrap": trial.suggest_categorical("bootstrap", [True, False]),
@@ -307,7 +307,7 @@ def get_params(trial, model, task):
         params = {
             "n_estimators": trial.suggest_int("n_estimators", 10, 10000),
             "max_depth": trial.suggest_int("max_depth", 2, 15),
-            "max_features": trial.suggest_categorical("max_features", ["auto", "sqrt", "log2", None]),
+            "max_features": trial.suggest_categorical("max_features", ["sqrt", "log2", None]),
             "min_samples_split": trial.suggest_int("min_samples_split", 2, 20),
             "min_samples_leaf": trial.suggest_int("min_samples_leaf", 1, 20),
             "bootstrap": trial.suggest_categorical("bootstrap", [True, False]),
@@ -326,7 +326,7 @@ def get_params(trial, model, task):
             "max_depth": trial.suggest_int("max_depth", 1, 15),
             "min_samples_split": trial.suggest_int("min_samples_split", 2, 20),
             "min_samples_leaf": trial.suggest_int("min_samples_leaf", 1, 20),
-            "max_features": trial.suggest_categorical("max_features", ["auto", "sqrt", "log2", None]),
+            "max_features": trial.suggest_categorical("max_features", ["sqrt", "log2", None]),
             "splitter": trial.suggest_categorical("splitter", ["best", "random"]),
         }
         if task in CLASSIFICATION_TASKS:


### PR DESCRIPTION
ExtreaTreesClassififer, DecisionTreeClassifier and RandomForestClassifier as it is no longer supported


[ExtraTreesClassifer](https://scikit-learn.org/dev/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html), [RandomForestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html) and [DecisionTreeClassifer](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html) no longer accept "auto" as a possible choice for max_features