### PR TITLE
datasets.load_metric -> evaluate.load in Extractive Question Answering

### DIFF
--- a/src/autotrain/trainers/extractive_question_answering/utils.py
+++ b/src/autotrain/trainers/extractive_question_answering/utils.py
@@ -3,7 +3,7 @@ import json
 import os
 
 import numpy as np
-from datasets import load_metric
+import evaluate
 from transformers import EvalPrediction
 
 from autotrain import logger
@@ -60,8 +60,8 @@ end_scores = outputs.end_logits
 ```
 """
 
-SQUAD_METRIC = load_metric("squad")
-SQUAD_V2_METRIC = load_metric("squad_v2")
+SQUAD_METRIC = evaluate.load("squad")
+SQUAD_V2_METRIC = evaluate.load("squad_v2")
 
 
 def postprocess_qa_predictions(


### PR DESCRIPTION
Support for load_metric has been removed in datasets@3.0.0. We now have to use the evaluate library evaluate.

load_metric incompatibility was causing an error that killed training when started in extractive question answering mode.