### PR TITLE
predictions format fix in Extractive Question Answering

### DIFF
--- a/src/autotrain/trainers/extractive_question_answering/utils.py
+++ b/src/autotrain/trainers/extractive_question_answering/utils.py
@@ -305,7 +305,7 @@ def post_processing_function_qa(examples, features, predictions, version_2_with_
             {"id": k, "prediction_text": v, "no_answer_probability": 0.0} for k, v in predictions.items()
         ]
     else:
-        formatted_predictions = [{"id": k, "prediction_text": v} for k, v in predictions.items()]
+        formatted_predictions = [{"id": str(k), "prediction_text": v} for k, v in predictions.items()]
 
     references = [{"id": str(ex["id"]), "answers": ex[config.answer_column]} for ex in examples]
     return EvalPrediction(predictions=formatted_predictions, label_ids=references)


### PR DESCRIPTION
k -> str(k)

if id is not string, then the following error interrupts evaluation during training -> Expected format: {'predictions': {'id': Value(dtype='string', id=None), 'prediction_text': Value(dtype='string', id=None)}, 'references': {'id': Value(dtype='string', id=None), 'answers': Sequence(feature={'text': Value(dtype='string', id=None), 'answer_start': Value(dtype='int32', id=None)}, length=-1, id=None)}},