### PR TITLE
Update utils.py

### DIFF
--- a/src/autotrain/app/utils.py
+++ b/src/autotrain/app/utils.py
@@ -6,6 +6,7 @@ import psutil
 import requests
 
 from autotrain import config, logger
+from functools import lru_cache
 
 
 def graceful_exit(signum, frame):
@@ -94,6 +95,7 @@ def kill_process_by_pid(pid):
         logger.error(f"Failed to send SIGTERM to process with PID {pid}: {e}")
 
 
+@lru_cache(maxsize=128)
 def token_verification(token):
     """
     Verifies the provided token with the Hugging Face API and retrieves user information.


### PR DESCRIPTION
It will keep sending requests to Huggingface to verify tokens. If the frequency exceeds the limit, Huggingface will reject it. This results in even if Huggingface is set to write token, it will still prompt that it is not The following error message will appear:
autotrain.app.utils:token_verification:138 - Failed to request /api/whoami-v2 - 429
ERROR    | 2025-03-24 01:57:16 | autotrain.app.ui_routes:user_authentication:343 - Failed to verify token: Invalid token (/api/whoami-v2). Please login with a write token.
This update is to address this issue:https://github.com/huggingface/autotrain-advanced/issues/873.