### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.sha }}
       package: autotrain-advanced

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -16,9 +16,9 @@ jobs:
     name: Check code quality
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/delete_doc_comment.yml
+++ b/.github/workflows/delete_doc_comment.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   delete:
-    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment.yml@main
+    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     secrets:
       comment_bot_token: ${{ secrets.COMMENT_BOT_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,10 +12,10 @@ jobs:
       group: 'aws-general-8-plus'
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9  # v1
 
       - name: Log in to Docker Hub
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       package_name: autotrain
     secrets:


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `docker.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `docker.yml` | `docker/setup-buildx-action` | `v1` | `v1` | `f211e3e9ded2…` |
| `code_quality.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `code_quality.yml` | `actions/setup-python` | `v2` | `v2` | `e9aba2c848f5…` |
| `build_documentation.yml` | `huggingface/doc-builder/.github/workflows/build_main_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `build_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/build_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `delete_doc_comment.yml` | `huggingface/doc-builder/.github/workflows/delete_doc_comment.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `upload_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#68