### PR TITLE
Harden dataset ZIP extraction and app launch commands

### DIFF
--- a/src/autotrain/app/colab.py
+++ b/src/autotrain/app/colab.py
@@ -373,8 +373,10 @@ def colab_app():
             with open("config.yml", "w") as f:
                 yaml.dump(config, f)
 
-            cmd = "autotrain --config config.yml"
-            process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            cmd = ["autotrain", "--config", "config.yml"]
+            process = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+            )
             while True:
                 output = process.stdout.readline()
                 if output == "" and process.poll() is not None:

--- a/src/autotrain/cli/run_app.py
+++ b/src/autotrain/cli/run_app.py
@@ -36,6 +36,19 @@ def run_app_command_factory(args):
     return RunAutoTrainAppCommand(args.port, args.host, args.share, args.workers, args.colab)
 
 
+def _uvicorn_command(host, port, workers):
+    return [
+        "uvicorn",
+        "autotrain.app.app:app",
+        "--host",
+        str(host),
+        "--port",
+        str(port),
+        "--workers",
+        str(workers),
+    ]
+
+
 class RunAutoTrainAppCommand(BaseAutoTrainCommand):
     """
     Command to run the AutoTrain application.
@@ -117,7 +130,7 @@ class RunAutoTrainAppCommand(BaseAutoTrainCommand):
         if self.share:
             from pyngrok import ngrok
 
-            os.system(f"fuser -n tcp -k {self.port}")
+            subprocess.run(["fuser", "-n", "tcp", "-k", str(self.port)], check=False)
             authtoken = os.environ.get("NGROK_AUTH_TOKEN", "")
             if authtoken.strip() == "":
                 logger.info("NGROK_AUTH_TOKEN not set")
@@ -132,25 +145,19 @@ class RunAutoTrainAppCommand(BaseAutoTrainCommand):
             logger.info(f"AutoTrain Public URL: {url}")
             logger.info("Please wait for the app to load...")
 
-        command = f"uvicorn autotrain.app.app:app --host {self.host} --port {self.port}"
-        command += f" --workers {self.workers}"
+        command = _uvicorn_command(self.host, self.port, self.workers)
 
         with open("autotrain.log", "w", encoding="utf-8") as log_file:
-            if sys.platform == "win32":
-                process = subprocess.Popen(
-                    command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, text=True, bufsize=1
-                )
+            popen_kwargs = {
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.STDOUT,
+                "text": True,
+                "bufsize": 1,
+            }
+            if sys.platform != "win32":
+                popen_kwargs["preexec_fn"] = os.setsid
 
-            else:
-                process = subprocess.Popen(
-                    command,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    shell=True,
-                    text=True,
-                    bufsize=1,
-                    preexec_fn=os.setsid,
-                )
+            process = subprocess.Popen(command, **popen_kwargs)
 
             output_thread = threading.Thread(target=handle_output, args=(process.stdout, log_file))
             output_thread.start()

--- a/src/autotrain/dataset.py
+++ b/src/autotrain/dataset.py
@@ -1,8 +1,10 @@
 import io
 import os
+import shutil
 import uuid
 import zipfile
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Dict, List, Optional
 
 import pandas as pd
@@ -30,6 +32,27 @@ from autotrain.preprocessor.vision import (
     ObjectDetectionPreprocessor,
 )
 from autotrain.preprocessor.vlm import VLMPreprocessor
+
+
+def _safe_extract_zip(zip_ref, destination):
+    for member in zip_ref.infolist():
+        member_path = PurePosixPath(member.filename.replace("\\", "/"))
+        if member_path.is_absolute() or ".." in member_path.parts:
+            raise ValueError(f"Unsafe path in zip archive: {member.filename}")
+    zip_ref.extractall(destination)
+
+
+def _extract_dataset_zip(data, destination):
+    data.seek(0)
+    content = data.read()
+    bytes_io = io.BytesIO(content)
+
+    with zipfile.ZipFile(bytes_io, "r") as zip_ref:
+        _safe_extract_zip(zip_ref, destination)
+
+    macosx_dir = os.path.join(destination, "__MACOSX")
+    if os.path.exists(macosx_dir):
+        shutil.rmtree(macosx_dir)
 
 
 def remove_non_image_files(folder):
@@ -124,30 +147,14 @@ class AutoTrainImageClassificationDataset:
             random_uuid = uuid.uuid4()
             train_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
             os.makedirs(train_dir, exist_ok=True)
-            self.train_data.seek(0)
-            content = self.train_data.read()
-            bytes_io = io.BytesIO(content)
 
-            zip_ref = zipfile.ZipFile(bytes_io, "r")
-            zip_ref.extractall(train_dir)
-            # remove the __MACOSX directory
-            macosx_dir = os.path.join(train_dir, "__MACOSX")
-            if os.path.exists(macosx_dir):
-                os.system(f"rm -rf {macosx_dir}")
+            _extract_dataset_zip(self.train_data, train_dir)
             remove_non_image_files(train_dir)
             if self.valid_data:
                 random_uuid = uuid.uuid4()
                 valid_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
                 os.makedirs(valid_dir, exist_ok=True)
-                self.valid_data.seek(0)
-                content = self.valid_data.read()
-                bytes_io = io.BytesIO(content)
-                zip_ref = zipfile.ZipFile(bytes_io, "r")
-                zip_ref.extractall(valid_dir)
-                # remove the __MACOSX directory
-                macosx_dir = os.path.join(valid_dir, "__MACOSX")
-                if os.path.exists(macosx_dir):
-                    os.system(f"rm -rf {macosx_dir}")
+                _extract_dataset_zip(self.valid_data, valid_dir)
                 remove_non_image_files(valid_dir)
         else:
             train_dir = self.train_data
@@ -223,30 +230,14 @@ class AutoTrainObjectDetectionDataset:
             random_uuid = uuid.uuid4()
             train_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
             os.makedirs(train_dir, exist_ok=True)
-            self.train_data.seek(0)
-            content = self.train_data.read()
-            bytes_io = io.BytesIO(content)
 
-            zip_ref = zipfile.ZipFile(bytes_io, "r")
-            zip_ref.extractall(train_dir)
-            # remove the __MACOSX directory
-            macosx_dir = os.path.join(train_dir, "__MACOSX")
-            if os.path.exists(macosx_dir):
-                os.system(f"rm -rf {macosx_dir}")
+            _extract_dataset_zip(self.train_data, train_dir)
             remove_non_image_files(train_dir)
             if self.valid_data:
                 random_uuid = uuid.uuid4()
                 valid_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
                 os.makedirs(valid_dir, exist_ok=True)
-                self.valid_data.seek(0)
-                content = self.valid_data.read()
-                bytes_io = io.BytesIO(content)
-                zip_ref = zipfile.ZipFile(bytes_io, "r")
-                zip_ref.extractall(valid_dir)
-                # remove the __MACOSX directory
-                macosx_dir = os.path.join(valid_dir, "__MACOSX")
-                if os.path.exists(macosx_dir):
-                    os.system(f"rm -rf {macosx_dir}")
+                _extract_dataset_zip(self.valid_data, valid_dir)
                 remove_non_image_files(valid_dir)
         else:
             train_dir = self.train_data
@@ -334,30 +325,14 @@ class AutoTrainVLMDataset:
             random_uuid = uuid.uuid4()
             train_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
             os.makedirs(train_dir, exist_ok=True)
-            self.train_data.seek(0)
-            content = self.train_data.read()
-            bytes_io = io.BytesIO(content)
 
-            zip_ref = zipfile.ZipFile(bytes_io, "r")
-            zip_ref.extractall(train_dir)
-            # remove the __MACOSX directory
-            macosx_dir = os.path.join(train_dir, "__MACOSX")
-            if os.path.exists(macosx_dir):
-                os.system(f"rm -rf {macosx_dir}")
+            _extract_dataset_zip(self.train_data, train_dir)
             remove_non_image_files(train_dir)
             if self.valid_data:
                 random_uuid = uuid.uuid4()
                 valid_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
                 os.makedirs(valid_dir, exist_ok=True)
-                self.valid_data.seek(0)
-                content = self.valid_data.read()
-                bytes_io = io.BytesIO(content)
-                zip_ref = zipfile.ZipFile(bytes_io, "r")
-                zip_ref.extractall(valid_dir)
-                # remove the __MACOSX directory
-                macosx_dir = os.path.join(valid_dir, "__MACOSX")
-                if os.path.exists(macosx_dir):
-                    os.system(f"rm -rf {macosx_dir}")
+                _extract_dataset_zip(self.valid_data, valid_dir)
                 remove_non_image_files(valid_dir)
         else:
             train_dir = self.train_data
@@ -434,30 +409,14 @@ class AutoTrainImageRegressionDataset:
             random_uuid = uuid.uuid4()
             train_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
             os.makedirs(train_dir, exist_ok=True)
-            self.train_data.seek(0)
-            content = self.train_data.read()
-            bytes_io = io.BytesIO(content)
 
-            zip_ref = zipfile.ZipFile(bytes_io, "r")
-            zip_ref.extractall(train_dir)
-            # remove the __MACOSX directory
-            macosx_dir = os.path.join(train_dir, "__MACOSX")
-            if os.path.exists(macosx_dir):
-                os.system(f"rm -rf {macosx_dir}")
+            _extract_dataset_zip(self.train_data, train_dir)
             remove_non_image_files(train_dir)
             if self.valid_data:
                 random_uuid = uuid.uuid4()
                 valid_dir = os.path.join(cache_dir, "autotrain", str(random_uuid))
                 os.makedirs(valid_dir, exist_ok=True)
-                self.valid_data.seek(0)
-                content = self.valid_data.read()
-                bytes_io = io.BytesIO(content)
-                zip_ref = zipfile.ZipFile(bytes_io, "r")
-                zip_ref.extractall(valid_dir)
-                # remove the __MACOSX directory
-                macosx_dir = os.path.join(valid_dir, "__MACOSX")
-                if os.path.exists(macosx_dir):
-                    os.system(f"rm -rf {macosx_dir}")
+                _extract_dataset_zip(self.valid_data, valid_dir)
                 remove_non_image_files(valid_dir)
         else:
             train_dir = self.train_data

--- a/src/autotrain/dataset.py
+++ b/src/autotrain/dataset.py
@@ -39,7 +39,13 @@ def _safe_extract_zip(zip_ref, destination):
         member_path = PurePosixPath(member.filename.replace("\\", "/"))
         if member_path.is_absolute() or ".." in member_path.parts:
             raise ValueError(f"Unsafe path in zip archive: {member.filename}")
-    zip_ref.extractall(destination)
+        target = os.path.join(destination, *member_path.parts)
+        if member.is_dir():
+            os.makedirs(target, exist_ok=True)
+            continue
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with zip_ref.open(member) as source, open(target, "wb") as output:
+            shutil.copyfileobj(source, output)
 
 
 def _extract_dataset_zip(data, destination):

--- a/src/autotrain/tests/test_dataset_zip.py
+++ b/src/autotrain/tests/test_dataset_zip.py
@@ -1,0 +1,90 @@
+import io
+import sys
+import types
+import zipfile
+
+import pytest
+
+
+def _install_stubs():
+    logging_module = types.ModuleType("autotrain.logging")
+
+    class _Logger:
+        def get_logger(self):
+            return None
+
+    logging_module.Logger = _Logger
+    sys.modules.setdefault("autotrain.logging", logging_module)
+    sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+
+    class _Preprocessor:
+        pass
+
+    preprocessor_modules = {
+        "autotrain.preprocessor.tabular": [
+            "TabularBinaryClassificationPreprocessor",
+            "TabularMultiClassClassificationPreprocessor",
+            "TabularMultiColumnRegressionPreprocessor",
+            "TabularMultiLabelClassificationPreprocessor",
+            "TabularSingleColumnRegressionPreprocessor",
+        ],
+        "autotrain.preprocessor.text": [
+            "LLMPreprocessor",
+            "SentenceTransformersPreprocessor",
+            "Seq2SeqPreprocessor",
+            "TextBinaryClassificationPreprocessor",
+            "TextExtractiveQuestionAnsweringPreprocessor",
+            "TextMultiClassClassificationPreprocessor",
+            "TextSingleColumnRegressionPreprocessor",
+            "TextTokenClassificationPreprocessor",
+        ],
+        "autotrain.preprocessor.vision": [
+            "ImageClassificationPreprocessor",
+            "ImageRegressionPreprocessor",
+            "ObjectDetectionPreprocessor",
+        ],
+        "autotrain.preprocessor.vlm": ["VLMPreprocessor"],
+    }
+    for module_name, names in preprocessor_modules.items():
+        module = types.ModuleType(module_name)
+        for name in names:
+            setattr(module, name, _Preprocessor)
+        sys.modules.setdefault(module_name, module)
+
+
+def _zip_bytes(entries):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zip_file:
+        for name, content in entries.items():
+            zip_file.writestr(name, content)
+    buffer.seek(0)
+    return buffer
+
+
+def test_extract_dataset_zip_rejects_traversal_path(tmp_path):
+    _install_stubs()
+    from autotrain.dataset import _extract_dataset_zip
+
+    archive = _zip_bytes({"../escape.png": "outside"})
+
+    with pytest.raises(ValueError, match="Unsafe path"):
+        _extract_dataset_zip(archive, tmp_path)
+
+    assert not (tmp_path.parent / "escape.png").exists()
+
+
+def test_extract_dataset_zip_removes_macosx_metadata(tmp_path):
+    _install_stubs()
+    from autotrain.dataset import _extract_dataset_zip
+
+    archive = _zip_bytes(
+        {
+            "__MACOSX/._image.png": "metadata",
+            "class-a/image.png": "image",
+        }
+    )
+
+    _extract_dataset_zip(archive, tmp_path)
+
+    assert not (tmp_path / "__MACOSX").exists()
+    assert (tmp_path / "class-a" / "image.png").read_text() == "image"

--- a/src/autotrain/tests/test_run_app.py
+++ b/src/autotrain/tests/test_run_app.py
@@ -1,0 +1,16 @@
+from autotrain.cli.run_app import _uvicorn_command
+
+
+def test_uvicorn_command_keeps_host_as_single_argument():
+    host = "127.0.0.1; touch /tmp/autotrain-shell-injection"
+
+    assert _uvicorn_command(host, 7860, 2) == [
+        "uvicorn",
+        "autotrain.app.app:app",
+        "--host",
+        host,
+        "--port",
+        "7860",
+        "--workers",
+        "2",
+    ]

--- a/src/autotrain/tests/test_trainer_common.py
+++ b/src/autotrain/tests/test_trainer_common.py
@@ -1,0 +1,80 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_common_module():
+    accelerate_stub = types.ModuleType("accelerate")
+
+    class PartialState:
+        process_index = 0
+
+    accelerate_stub.PartialState = PartialState
+    sys.modules.setdefault("accelerate", accelerate_stub)
+
+    hf_stub = types.ModuleType("huggingface_hub")
+    hf_stub.HfApi = object
+    sys.modules.setdefault("huggingface_hub", hf_stub)
+
+    pydantic_stub = types.ModuleType("pydantic")
+
+    class BaseModel:
+        def __init__(self, **data):
+            for key, value in data.items():
+                setattr(self, key, value)
+
+    pydantic_stub.BaseModel = BaseModel
+    sys.modules.setdefault("pydantic", pydantic_stub)
+
+    transformers_stub = types.ModuleType("transformers")
+    transformers_stub.TrainerCallback = object
+    transformers_stub.TrainerControl = object
+    transformers_stub.TrainerState = object
+    transformers_stub.TrainingArguments = object
+    sys.modules.setdefault("transformers", transformers_stub)
+
+    sys.modules.setdefault("requests", types.ModuleType("requests"))
+
+    autotrain_stub = types.ModuleType("autotrain")
+    autotrain_stub.__path__ = [str(Path(__file__).resolve().parents[1])]
+    autotrain_stub.is_colab = lambda: False
+
+    class Logger:
+        def info(self, *args, **kwargs):
+            pass
+
+        def warning(self, *args, **kwargs):
+            pass
+
+        def error(self, *args, **kwargs):
+            pass
+
+    autotrain_stub.logger = Logger()
+    sys.modules.setdefault("autotrain", autotrain_stub)
+
+    module_path = Path(__file__).resolve().parents[1] / "trainers" / "common.py"
+    spec = importlib.util.spec_from_file_location("autotrain_trainers_common", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_remove_autotrain_data_uses_rmtree_without_shell(tmp_path):
+    module = load_common_module()
+    project = tmp_path / "project; touch shell-injection"
+    data_dir = project / "autotrain-data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "data.txt").write_text("data")
+
+    def fail_if_called(command):
+        raise AssertionError(f"shell should not be used: {command}")
+
+    module.os.system = fail_if_called
+    module.remove_global_step = lambda directory: None
+
+    config = types.SimpleNamespace(project_name=str(project))
+    module.remove_autotrain_data(config)
+
+    assert not data_dir.exists()

--- a/src/autotrain/trainers/common.py
+++ b/src/autotrain/trainers/common.py
@@ -72,7 +72,7 @@ def remove_autotrain_data(config):
     Raises:
         OSError: If the removal of the directory fails.
     """
-    os.system(f"rm -rf {config.project_name}/autotrain-data")
+    shutil.rmtree(os.path.join(config.project_name, "autotrain-data"), ignore_errors=True)
     remove_global_step(config.project_name)
 
 


### PR DESCRIPTION
## Summary
- reject unsafe paths before extracting uploaded dataset ZIP files
- manually extract validated ZIP members instead of calling `extractall()`
- remove shell-based cleanup for generated AutoTrain data
- launch app and Colab commands with argv lists instead of shell strings
- add focused regression tests for ZIP traversal, cleanup without shell, and app command construction

## Tests
- `PYTHONPATH=src uv run --no-project --with pytest --with loguru python -m pytest -q src/autotrain/tests/test_run_app.py src/autotrain/tests/test_dataset_zip.py`
- `PYTHONPATH=src uv run --no-project --with pytest --with loguru pytest -q src/autotrain/tests/test_dataset_zip.py src/autotrain/tests/test_trainer_common.py`
- `python3 -m py_compile src/autotrain/cli/run_app.py src/autotrain/app/colab.py src/autotrain/tests/test_run_app.py`
- `python3 -m py_compile src/autotrain/dataset.py src/autotrain/trainers/common.py src/autotrain/tests/test_dataset_zip.py src/autotrain/tests/test_trainer_common.py`
- `uv run --no-project --with ruff ruff check src/autotrain/cli/run_app.py src/autotrain/app/colab.py src/autotrain/tests/test_run_app.py src/autotrain/tests/test_dataset_zip.py`
- `uv run --no-project --with ruff ruff check src/autotrain/dataset.py src/autotrain/trainers/common.py src/autotrain/tests/test_dataset_zip.py src/autotrain/tests/test_trainer_common.py`
- `git diff --check`
